### PR TITLE
Fix with_log_context decorator overriding of function name

### DIFF
--- a/src/parrottools/__version__.py
+++ b/src/parrottools/__version__.py
@@ -1,2 +1,2 @@
 __title__ = "parrottools"
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/parrottools/logging/configure.py
+++ b/src/parrottools/logging/configure.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from contextlib import contextmanager
+from functools import wraps
 from typing import Any, Dict, Optional, Union
 
 import sentry_sdk
@@ -52,6 +53,7 @@ def log_context(**kwargs):
 
 def with_log_context(*context_kwargs):
     def decorator(function):
+        @wraps(function)
         def wrapper(*args, **kwargs):
             items = {arg: kwargs[arg] for arg in context_kwargs if arg in kwargs}
             original_ctx = update_log_context(**items)

--- a/tests/parrottools/logging/configure_test.py
+++ b/tests/parrottools/logging/configure_test.py
@@ -140,9 +140,26 @@ def __test_with_log_context_decorator(logger, key2):
     logger.info("Info")
 
 
+@with_log_context()
+def decorated_function():
+    """
+    Test docstring
+    """
+    pass
+
+
 def test_with_log_context_decorator(capsys):
     configure_logging()
     logger = logging.getLogger("test_with_log_context_decorator")
+
+    assert decorated_function.__name__ == "decorated_function"
+    assert decorated_function.__module__ == "configure_test"
+    assert (
+        decorated_function.__doc__
+        == """
+    Test docstring
+    """
+    )
 
     _test_with_log_context_decorator(logger, key="value")
 


### PR DESCRIPTION
There was problem with `with_log_context` decorator when decorating Celery task, because Celery is registering function task by function name and module and without `wraps()` the name of task was always `wrapper`. See https://github.com/celery/celery/blob/master/celery/app/base.py#L450