### PR TITLE
Do not call sentry_sdk.init

### DIFF
--- a/src/parrottools/logging/configure.py
+++ b/src/parrottools/logging/configure.py
@@ -200,9 +200,6 @@ def configure_logging(
         foreign_pre_chain=foreign_pre_chain,
     )
 
-    if sentry_enabled:
-        sentry_sdk.init()
-
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(level)
     stream_handler.setFormatter(formatter)


### PR DESCRIPTION
Every project does this separately anyway and calling it only overwrites variables set by previous init (environment, release version and so on)
Alternatively, we could only call it here, but that would mean passing sentry-only options in as well, let me know what you think is better.